### PR TITLE
Include 921600 baud for u-blox ZED-F9P as well

### DIFF
--- a/sl_serial.c
+++ b/sl_serial.c
@@ -141,7 +141,8 @@ static baudTrans validRates[] = {
         {  57600,  B57600 },
         { 115200, B115200 },
         { 230400, B230400 },
-        { 460800, B460800 }
+        { 460800, B460800 },
+        { 921600, B921600 }
 };
 
 // Translate the given integer baud rate into the constant needed by termios to specify that baud rate.  If the given
@@ -286,7 +287,7 @@ extern slReturn asciiBaudRateSynchronizer( int fdPort, int maxTimeMs, int verbos
 
 
 // Determines the baud rate on the given serial port, by sequentially trying all the possible baud rates, starting
-// with the highest (230,400) and working down to the given minimum baud rate.  If it finds a baud rate that
+// with the highest (921600) and working down to the given minimum baud rate.  If it finds a baud rate that
 // synchronizes using the given synchronizer, it stops and returns Ok with that baud rate as additional info, leaving
 // the host's port set to that baud rate.  If if fails to find a baud rate, returns an error.
 extern slReturn autoBaudRate( int fdPort, int minBaud, baudRateSynchronizer synchronizer, int verbosity ) {
@@ -300,10 +301,10 @@ extern slReturn autoBaudRate( int fdPort, int minBaud, baudRateSynchronizer sync
         return makeErrorMsgReturn( ERR_CAUSE( gsiResp ), "problem getting speed information" );
     int maxMs = (int) max_ll( 4000, si.nsChar * 250 / 1000000 );
 
-    int bauds[] = { 460800, 230400, 115200, 57600, 38400, 19200, 9600, 4800, 2400,
+    int bauds[] = { 921600, 460800, 230400, 115200, 57600, 38400, 19200, 9600, 4800, 2400,
                     1800, 1200, 600, 300, 200, 150, 134, 110, 75, 50   };
 
-    if( verbosity >= 3 ) printf( "Trying baud rates from 460800 to %d...\n", minBaud );
+    if( verbosity >= 3 ) printf( "Trying baud rates from 921600 to %d...\n", minBaud );
 
     for( int i = 0; (i < ARRAY_SIZE( bauds ) ) && (bauds[i] >= minBaud); i++ ) {
 
@@ -324,5 +325,5 @@ extern slReturn autoBaudRate( int fdPort, int minBaud, baudRateSynchronizer sync
         }
     }
     printf( "Could not synchronize on any baud rate...\n" );
-    return makeErrorFmtMsgReturn( ERR_ROOT, "could not synchronize at any baud rate from 460800 to %d", minBaud );
+    return makeErrorFmtMsgReturn( ERR_ROOT, "could not synchronize at any baud rate from 921600 to %d", minBaud );
 }


### PR DESCRIPTION
u-blox ZED-F9P can run 921600 baud at its UART interface, see https://content.u-blox.com/sites/default/files/documents/ZED-F9P-01B_DataSheet_UBX-17051259.pdf, section 5.1